### PR TITLE
Fix stats and linux native build

### DIFF
--- a/build/linux/Makefile
+++ b/build/linux/Makefile
@@ -336,6 +336,16 @@ CGOBJ_ = \
   $(B)/$(MOD)/cgame/cg_cvardescriptions.o \
   $(B)/$(MOD)/cgame/cg_crosshair.o \
   $(B)/$(MOD)/cgame/cg_chatfilter.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_element_decor.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_elements.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_layout.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_lexer_commands.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_lexer_parser.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_lexer.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_private.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_tablebuilder.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud_util.o \
+  $(B)/$(MOD)/cgame/cg_cherryhud.o \
   $(B)/$(MOD)/cgame/cg_consolecmds.o \
   $(B)/$(MOD)/cgame/cg_customloc.o \
   $(B)/$(MOD)/cgame/cg_draw.o \
@@ -360,6 +370,9 @@ CGOBJ_ = \
   $(B)/$(MOD)/cgame/cg_osphud.o \
   $(B)/$(MOD)/cgame/cg_osputil.o \
   $(B)/$(MOD)/cgame/cg_unlagged.o \
+  $(B)/$(MOD)/cgame/cg_be_util.o \
+  $(B)/$(MOD)/cgame/cg_be_stats.o \
+  $(B)/$(MOD)/cgame/cg_bescoreboard.o \
   $(B)/$(MOD)/cgame/cg_superhud.o \
   $(B)/$(MOD)/cgame/cg_superhud_configparser.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_ammomessage.o \
@@ -372,6 +385,7 @@ CGOBJ_ = \
   $(B)/$(MOD)/cgame/cg_superhud_element_fragmessage.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_gametime.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_gametype.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_grid.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_itempickup.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_itempickupicon.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_localtime.o \
@@ -380,6 +394,8 @@ CGOBJ_ = \
   $(B)/$(MOD)/cgame/cg_superhud_element_ng.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_ngp.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_obituaries.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_player_name.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_player_stats.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_powerup.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_pred.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_rankmessage.o \
@@ -395,13 +411,16 @@ CGOBJ_ = \
   $(B)/$(MOD)/cgame/cg_superhud_element_sbhi.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_score.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_specmessage.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_spectators.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_speed.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_target_name.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_target_status.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_team.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_teamcount.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_tempAcc.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_vmw.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_warmupinfo.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_weapon_stats.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_weaponlist.o \
   $(B)/$(MOD)/cgame/cg_superhud_private.o \
   $(B)/$(MOD)/cgame/cg_superhud_util.o \

--- a/code/cgame/cg_be_stats.c
+++ b/code/cgame/cg_be_stats.c
@@ -304,6 +304,10 @@ static void CG_BEStatsBuildGeneral_Tournament(BEStatToken_t tokens[32][12], int*
 	int col = 0;
 	const newStatsInfo_t* s = &cgs.be.newStats;
 
+	if (outCols == NULL) {
+		outCols = &col;
+	}
+
 	if (cg_bestats_style.integer == 2)
 	{
 		// 1st row
@@ -366,6 +370,11 @@ static void CG_BEStatsBuildGeneral_Team(BEStatToken_t tokens[32][12], int* outCo
 	const newStatsInfo_t* s = &cgs.be.newStats;
 	int style = cg_bestats_style.integer;  // глобальная переменная/настройка
 	qboolean isFreeze = cgs.osp.gameTypeFreeze;
+
+	if (outCols == NULL) {
+		outCols = &col;
+	}
+
 	if (style == 2)
 	{
 		// Titles
@@ -459,6 +468,10 @@ static void CG_BEStatsBuildGeneral_CTF(BEStatToken_t tokens[32][12], int* outCol
 	const newStatsInfo_t* s = &cgs.be.newStats;
 	char timeStr[MAX_TOKEN_LEN];
 
+	if (outCols == NULL) {
+		outCols = &col;
+	}
+
 	if (cg_bestats_style.integer == 2)
 	{
 		int mins = s->flagTime / 60;
@@ -548,6 +561,10 @@ static void CG_BEStatsBuildGeneral_CA(BEStatToken_t tokens[32][12], int* outCols
 	int col = 0;
 	const newStatsInfo_t* s = &cgs.be.newStats;
 
+	if (outCols == NULL) {
+		outCols = &col;
+	}
+
 	if (cg_bestats_style.integer == 2)
 	{
 		// 1st row
@@ -600,8 +617,14 @@ static void CG_BEStatsBuildGeneral_CA(BEStatToken_t tokens[32][12], int* outCols
 
 static void CG_BEStatsBuildGeneral_Default(BEStatToken_t tokens[32][12], int* outCols)
 {
+	int dummy = 0;
+
 	int style = cg_bestats_style.integer;
 	const newStatsInfo_t* s = &cgs.be.newStats;
+
+	if (outCols == NULL) {
+		outCols = &dummy;
+	}
 
 	if (style == 2)
 	{

--- a/code/cgame/cg_bescoreboard.c
+++ b/code/cgame/cg_bescoreboard.c
@@ -1062,6 +1062,97 @@ static void DrawScoreboardColumnHeaders(scoreboardContext_t* sb, float baseX, co
     }
 }
 
+// Draw the background and frame for scoreboard (unified for all gametypes)
+static void DrawScoreboardBackgroundAndFrame(float frameX, float frameY, float frameW, float frameH, scoreboardContext_t* sb, int gametype, int team) 
+{
+    vec4_t bgColor, hdrColor;
+    vec4_t tempbgColor, temphdrColor;
+
+    // Set team-specific colors for team-based gametypes
+    if (gametype >= GT_TEAM) {
+        if (team == TEAM_RED) {
+            if (cgs.be.sbSettings.redColors.bodyBg[3] >= 0.0f)
+            {
+                Vector4Copy(cgs.be.sbSettings.redColors.bodyBg, bgColor);
+            }
+            else
+            {
+                Vector4Copy(scoreboard_rtColor, bgColor);
+            }
+            if (cgs.be.sbSettings.redColors.headerBg[3] >= 0.0f)
+            {
+                Vector4Copy(cgs.be.sbSettings.redColors.headerBg, hdrColor);
+            }
+            else
+            {
+                Vector4Copy(scoreboard_rtColor, hdrColor);
+            }
+
+        } else if (team == TEAM_BLUE) {
+            if (cgs.be.sbSettings.blueColors.bodyBg[3] >= 0.0f)
+            {
+                Vector4Copy(cgs.be.sbSettings.blueColors.bodyBg, bgColor);
+            }
+            else
+            {
+                Vector4Copy(scoreboard_btColor, bgColor);
+            }
+            if (cgs.be.sbSettings.blueColors.headerBg[3] >= 0.0f)
+            {
+                Vector4Copy(cgs.be.sbSettings.blueColors.headerBg, hdrColor);
+            }
+            else
+            {
+                Vector4Copy(scoreboard_btColor, hdrColor);
+            }
+
+        }
+    }
+    // Handle single player and other non-team modes
+    else if (gametype <= GT_SINGLE_PLAYER) {
+
+         if (cgs.be.sbSettings.ffaColors.bodyBg[3] >= 0.0f)
+         {
+             Vector4Copy(cgs.be.sbSettings.ffaColors.bodyBg, bgColor);
+         }
+         else
+         {
+             Vector4Copy(sbSet->background, bgColor);
+         }
+           
+        if (cgs.be.sbSettings.ffaColors.headerBg[3] >= 0.0f)
+        {
+            Vector4Copy(cgs.be.sbSettings.ffaColors.headerBg, hdrColor);
+        }
+        else
+        {
+            Vector4Copy(sbSet->background, hdrColor);
+        }
+    }
+
+    // this should work for all gametypes
+    if (team == TEAM_SPECTATOR) {
+        if (cgs.be.sbSettings.specColors.bodyBg[3] >= 0.0f)
+        {
+            Vector4Copy(cgs.be.sbSettings.specColors.bodyBg, bgColor);
+        }
+        else
+        {
+            Vector4Copy(sb->background, bgColor);
+        }
+    }
+
+    // Apply the colors
+    CG_OSPAdjustTeamColor(bgColor, tempbgColor);
+    CG_OSPAdjustTeamColor(hdrColor, temphdrColor);
+
+    CG_FillRect(frameX, frameY, frameW, frameH, temphdrColor);
+    CG_FillRect(frameX, frameY, frameW, sb->headerHeight, tempbgColor);
+
+    CG_OSPDrawFrameAdjusted(frameX, frameY, frameW, frameH, sb->defaultBorder, sb->borderColor, qtrue);
+    CG_OSPDrawFrameAdjusted(frameX, frameY, frameW, frameH, sb->defaultBorder, colorBlack, qfalse);
+}
+
 // Helper function for drawing scoreboard frame (unified for FFA and Team)
 static void CG_DrawScoreboardFrameUnified(short isTeamMode, short forceDouble, int (*drawListFunc)(short)) {
     int i;
@@ -1169,7 +1260,7 @@ static void CG_DrawScoreboardFrameUnified(short isTeamMode, short forceDouble, i
         // Single column mode
         CG_CalcScoreboardColumnWidths(sbSet->baseX, sbSet);
 
-        DrawScoreboardBackgroundAndFrame(frameX_left, frameY, frameW, frameH, sbSet, qfalse);
+        DrawScoreboardBackgroundAndFrame(frameX_left, frameY, frameW, frameH, sbSet, qfalse, 0);
 
         // Draw header info: both on left base
         CG_OSPDrawStringNew(sbSet->baseX, sbSet->headerY, topHeader, infoColor, sbSet->title.shadowColor,
@@ -1287,98 +1378,6 @@ int CG_DrawScoreboardTeam(short isDouble) {
     max_y = (y_left > y_right ? y_left : y_right);
     max_y = CG_DrawSpectatorList(max_y, sbSet->baseX, qtrue); // Always double for spectators too
     return max_y;
-}
-
-
-// Draw the background and frame for scoreboard (unified for all gametypes)
-static void DrawScoreboardBackgroundAndFrame(float frameX, float frameY, float frameW, float frameH, scoreboardContext_t* sb, int gametype, int team) 
-{
-    vec4_t bgColor, hdrColor;
-    vec4_t tempbgColor, temphdrColor;
-
-    // Set team-specific colors for team-based gametypes
-    if (gametype >= GT_TEAM) {
-        if (team == TEAM_RED) {
-            if (cgs.be.sbSettings.redColors.bodyBg[3] >= 0.0f)
-            {
-                Vector4Copy(cgs.be.sbSettings.redColors.bodyBg, bgColor);
-            }
-            else
-            {
-                Vector4Copy(scoreboard_rtColor, bgColor);
-            }
-            if (cgs.be.sbSettings.redColors.headerBg[3] >= 0.0f)
-            {
-                Vector4Copy(cgs.be.sbSettings.redColors.headerBg, hdrColor);
-            }
-            else
-            {
-                Vector4Copy(scoreboard_rtColor, hdrColor);
-            }
-
-        } else if (team == TEAM_BLUE) {
-            if (cgs.be.sbSettings.blueColors.bodyBg[3] >= 0.0f)
-            {
-                Vector4Copy(cgs.be.sbSettings.blueColors.bodyBg, bgColor);
-            }
-            else
-            {
-                Vector4Copy(scoreboard_btColor, bgColor);
-            }
-            if (cgs.be.sbSettings.blueColors.headerBg[3] >= 0.0f)
-            {
-                Vector4Copy(cgs.be.sbSettings.blueColors.headerBg, hdrColor);
-            }
-            else
-            {
-                Vector4Copy(scoreboard_btColor, hdrColor);
-            }
-
-        }
-    }
-    // Handle single player and other non-team modes
-    else if (gametype <= GT_SINGLE_PLAYER) {
-
-         if (cgs.be.sbSettings.ffaColors.bodyBg[3] >= 0.0f)
-         {
-             Vector4Copy(cgs.be.sbSettings.ffaColors.bodyBg, bgColor);
-         }
-         else
-         {
-             Vector4Copy(sbSet->background, bgColor);
-         }
-           
-        if (cgs.be.sbSettings.ffaColors.headerBg[3] >= 0.0f)
-        {
-            Vector4Copy(cgs.be.sbSettings.ffaColors.headerBg, hdrColor);
-        }
-        else
-        {
-            Vector4Copy(sbSet->background, hdrColor);
-        }
-    }
-
-    // this should work for all gametypes
-    if (team == TEAM_SPECTATOR) {
-        if (cgs.be.sbSettings.specColors.bodyBg[3] >= 0.0f)
-        {
-            Vector4Copy(cgs.be.sbSettings.specColors.bodyBg, bgColor);
-        }
-        else
-        {
-            Vector4Copy(sb->background, bgColor);
-        }
-    }
-
-    // Apply the colors
-    CG_OSPAdjustTeamColor(bgColor, tempbgColor);
-    CG_OSPAdjustTeamColor(hdrColor, temphdrColor);
-
-    CG_FillRect(frameX, frameY, frameW, frameH, temphdrColor);
-    CG_FillRect(frameX, frameY, frameW, sb->headerHeight, tempbgColor);
-
-    CG_OSPDrawFrameAdjusted(frameX, frameY, frameW, frameH, sb->defaultBorder, sb->borderColor, qtrue);
-    CG_OSPDrawFrameAdjusted(frameX, frameY, frameW, frameH, sb->defaultBorder, colorBlack, qfalse);
 }
 
 // Main scoreboard drawing function for Team mode

--- a/code/cgame/cg_cherryhud.h
+++ b/code/cgame/cg_cherryhud.h
@@ -1,5 +1,5 @@
-#ifndef CG_SUPERHUD_H
-#define CG_SUPERHUD_H
+#ifndef CG_CHERRYHUD_H
+#define CG_CHERRYHUD_H
 
 #include "cg_local.h"
 

--- a/code/cgame/cg_cherryhud_elements.c
+++ b/code/cgame/cg_cherryhud_elements.c
@@ -4,6 +4,7 @@
 // Global element counter to limit memory usage
 static int g_elementCount = 0;
 #include "../qcommon/q_shared.h"
+#include "../qcommon/qcommon.h"
 
 /*
  * Common element helper functions to reduce code duplication

--- a/code/cgame/cg_cherryhud_layout.c
+++ b/code/cgame/cg_cherryhud_layout.c
@@ -1,6 +1,8 @@
 #include "cg_cherryhud_private.h"
 #include "cg_local.h"
 
+#include "../qcommon/qcommon.h"
+
 static cherryhudLayoutManager_t g_layoutManager = {0};
 
 #define MAX_LAYOUT_PROPERTIES 1024
@@ -408,6 +410,8 @@ void CG_CHUDLayoutSetDefaultProperties(cherryhudLayoutProperties_t* props) {
     
     props->isSet = qtrue;
 }
+
+void CG_CHUDLayoutCalculateElementInternal(cherryhudElement_t* element, const cherryhudLayoutContext_t* context, cherryhudLayoutBounds_t* bounds);
 
 cherryhudLayoutBounds_t* CG_CHUDLayoutCalculateElement(cherryhudElement_t* element, const cherryhudLayoutContext_t* context) {
     layoutBoundsEntry_t* entry;

--- a/code/cgame/cg_cherryhud_lexer.c
+++ b/code/cgame/cg_cherryhud_lexer.c
@@ -1,6 +1,8 @@
 #include "cg_local.h"
 #include "cg_cherryhud_private.h"
 
+#include "../qcommon/qcommon.h"
+
 static char CG_CHUDLexerPeek(cherryhud_lexer_t* lexer);
 static char CG_CHUDLexerAdvance(cherryhud_lexer_t* lexer);
 static void CG_CHUDLexerSkipWhitespace(cherryhud_lexer_t* lexer);

--- a/code/cgame/cg_cherryhud_private.c
+++ b/code/cgame/cg_cherryhud_private.c
@@ -751,14 +751,14 @@ void CG_CHUDGetActivePos(const cherryhudConfig_t* config, float currentHeight, v
     if (mode) {
         prefixedConfig = CG_CHUDGetPrefixedConfig(config, mode);
         if (prefixedConfig && prefixedConfig->pos.isSet) {
-            Vector4Copy(prefixedConfig->pos.value, result);
+            Vector2Copy(prefixedConfig->pos.value, result);
             return;
         }
     }
     
     // Return default pos
     if (config->pos.isSet) {
-        Vector4Copy(config->pos.value, result);
+        Vector2Copy(config->pos.value, result);
     } else {
         Vector4Set(result, 0, 0, 0, 0);
     }
@@ -781,7 +781,7 @@ void CG_CHUDGetActiveSize(const cherryhudConfig_t* config, float currentHeight, 
         if (prefixedConfig) {
         }
         if (prefixedConfig && prefixedConfig->size.isSet) {
-            Vector4Copy(prefixedConfig->size.value, result);
+            Vector2Copy(prefixedConfig->size.value, result);
             return;
         } else {
         }
@@ -789,7 +789,7 @@ void CG_CHUDGetActiveSize(const cherryhudConfig_t* config, float currentHeight, 
     
     // Return default size
     if (config->size.isSet) {
-        Vector4Copy(config->size.value, result);
+        Vector2Copy(config->size.value, result);
     } else {
         Vector4Set(result, 0, 0, 0, 0);
     }
@@ -811,7 +811,7 @@ void CG_CHUDGetActiveSizeFromContainer(const cherryhudConfig_t* config, const ch
     if (mode) {
         prefixedConfig = CG_CHUDGetPrefixedConfig(config, mode);
         if (prefixedConfig && prefixedConfig->size.isSet) {
-            Vector4Copy(prefixedConfig->size.value, result);
+            Vector2Copy(prefixedConfig->size.value, result);
             return;
         } else {
         }
@@ -819,7 +819,7 @@ void CG_CHUDGetActiveSizeFromContainer(const cherryhudConfig_t* config, const ch
     
     // Return default size
     if (config->size.isSet) {
-        Vector4Copy(config->size.value, result);
+        Vector2Copy(config->size.value, result);
     } else {
         Vector4Set(result, 0, 0, 0, 0);
     }
@@ -841,14 +841,14 @@ void CG_CHUDGetActivePosFromContainer(const cherryhudConfig_t* config, const cha
     if (mode) {
         prefixedConfig = CG_CHUDGetPrefixedConfig(config, mode);
         if (prefixedConfig && prefixedConfig->pos.isSet) {
-            Vector4Copy(prefixedConfig->pos.value, result);
+            Vector2Copy(prefixedConfig->pos.value, result);
             return;
         }
     }
     
     // Return default pos
     if (config->pos.isSet) {
-        Vector4Copy(config->pos.value, result);
+        Vector2Copy(config->pos.value, result);
     } else {
         Vector4Set(result, 0, 0, 0, 0);
     }

--- a/code/cgame/cg_cherryhud_private.c
+++ b/code/cgame/cg_cherryhud_private.c
@@ -1,5 +1,7 @@
 #include "cg_cherryhud_private.h"
 
+#include "../qcommon/qcommon.h"
+
 static cherryhudGlobalContext_t cherryhudGlobalContext;
 
 // Global storage for prefixed configs

--- a/code/cgame/cg_cherryhud_private.h
+++ b/code/cgame/cg_cherryhud_private.h
@@ -675,6 +675,9 @@ void CG_CHUDConfigPickImageBorderColor(const cherryhudConfig_t* config, float* c
 qboolean CG_CHUDConfigHasImageBackground(const cherryhudConfig_t* config);
 qboolean CG_CHUDConfigHasImageBorder(const cherryhudConfig_t* config);
 
+void CG_CHUDConfigPickBorderColor(const cherryhudConfig_t* config, float* color, qboolean alphaOverride);
+
+
 
 typedef struct
 {
@@ -831,6 +834,7 @@ typedef struct {
     qboolean isContainerTitle;      // Whether this title is associated with a container
 } cherryhudTitleBlock_t;
 
+void CG_CHUDSetDefaultElementProperties(cherryhudConfig_t* config);
 void CG_CHUDCreateTitleBlock(const cherryhudConfig_t* config);
 void CG_CHUDCreateTitleBlockForContainer(const cherryhudConfig_t* config, const char* containerType);
 void CG_CHUDUpdateTitleBlockConfig(int blockIndex, const cherryhudConfig_t* config);
@@ -852,6 +856,7 @@ void CG_CHUDSetConfigByType(const char* type, const cherryhudConfig_t* config);
 const cherryhudConfig_t* CG_CHUDGetConfigByType(const char* type);
 qboolean CG_CHUDIsConfigLoadedByType(const char* type);
 void CG_CHUDClearConfigByType(const char* type);
+void CG_CHUDClearConfig(cherryhudConfig_t* config);
 void CG_CHUDClearAllConfigs(void);
 
 // Compact and double config management
@@ -1008,6 +1013,7 @@ void CG_CHUDAddElementToBlock(cherryhudBlock_t* block, cherryhudElement_t* eleme
 
 // Rendering functions
 void CG_CHUDRenderBlock(cherryhudBlock_t* block, float parentX, float parentY);
+void CG_CHUDRenderElementWithMode(cherryhudElement_t* element, const char* containerType, float currentHeight);
 
 // Configuration inheritance
 void CG_CHUDInheritConfig(cherryhudConfig_t* child, const cherryhudConfig_t* parent);
@@ -1277,6 +1283,9 @@ cherryhud_parser_t* CG_CHUDLexerParserCreate(const char* input);
 void CG_CHUDLexerParserDestroy(cherryhud_parser_t* parser);
 cherryhudConfigParseStatus_t CG_CHUDLexerParserParse(cherryhud_parser_t* parser, cherryhudConfig_t* config);
 
+void CG_CHUDLexerParserResetStatics(void);
+void CG_CHUDResetElementCounter(void);
+
 cherryhud_token_t* CG_CHUDLexerParserGetCurrentToken(cherryhud_parser_t* parser);
 cherryhud_token_t* CG_CHUDLexerParserPeekToken(cherryhud_parser_t* parser, int offset);
 qboolean CG_CHUDLexerParserIsAtEnd(cherryhud_parser_t* parser);
@@ -1430,6 +1439,9 @@ void CG_CHUDRenderContainerBackgroundFromBounds(const cherryhudConfig_t* config,
 void CG_CHUDRenderContainerBackgroundFromBoundsWithHeight(const cherryhudConfig_t* config, cherryhudLayoutBounds_t* bounds, float currentHeight);
 qboolean CG_CHUDValidateClientNum(int clientNum);
 void CG_CHUDRenderElementText(const cherryhudConfig_t* config, cherryhudTextContext_t* textCtx, const char* displayText);
+
+void CG_CHUDSetTextContextFromBounds(cherryhudTextContext_t* textCtx, cherryhudLayoutBounds_t* bounds);
+void CG_CHUDSetDrawContextFromBounds(cherryhudDrawContext_t* drawCtx, cherryhudLayoutBounds_t* bounds);
 
 // Generic type handler lookup structure
 typedef struct {

--- a/code/cgame/cg_cherryhud_tablebuilder.c
+++ b/code/cgame/cg_cherryhud_tablebuilder.c
@@ -1,6 +1,7 @@
 #include "cg_cherryhud_private.h"
 #include "cg_local.h"
 #include "../qcommon/q_shared.h"  // For vec2_t and VectorCopy
+#include "../qcommon/qcommon.h" 
 
 // ============================================================================
 // GLOBAL VARIABLES AND DATA STRUCTURES
@@ -31,7 +32,6 @@ static void CG_CHUDTableRenderBorder(cherryhudTable_t* table);
 // Configuration helpers
 static void CG_CHUDSetDefaultTableProperties(cherryhudTable_t* table);
 static void CG_CHUDGetConfigWithFallback(cherryhudConfig_t* config, const char* type);
-void CG_CHUDSetDefaultElementProperties(cherryhudConfig_t* config);
 
 qboolean CG_CHUDTableRenderBackgroundAndBorder(cherryhudTable_t* table);
 qboolean CG_CHUDTableRowRenderBackgroundAndBorder(cherryhudTable_t* table, cherryhudTableRow_t* row);

--- a/code/cgame/cg_cherryhud_tablebuilder.c
+++ b/code/cgame/cg_cherryhud_tablebuilder.c
@@ -493,8 +493,6 @@ static void CG_CHUDTableGetModifiedTemplate(cherryhudConfig_t* result, cherryhud
                 if (prefixedConfig->size.isSet) {
                     result->size.value[0] = prefixedConfig->size.value[0];
                     result->size.value[1] = prefixedConfig->size.value[1];
-                    result->size.value[2] = prefixedConfig->size.value[2];
-                    result->size.value[3] = prefixedConfig->size.value[3];
                     result->size.isSet = qtrue;
                 } else {
                 }

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -2754,7 +2754,7 @@ void CG_DrawPlayerIndicator(int clientNum)
 
 		rectY += h;
 
-		if (isSpec && cg_teamIndicator.integer & PI_SPECTATOR)
+		if (isSpec && (cg_teamIndicator.integer & PI_SPECTATOR))
 		{
 			if (ci->team == TEAM_RED)
 				Vector4Copy(cgs.be.redTeamColor, teamColor);
@@ -2773,7 +2773,7 @@ void CG_DrawPlayerIndicator(int clientNum)
 			}
 		}
 		teamColor[3] = nameColor[3];
-		if (isSpec && cg_teamIndicator.integer & PI_SPECTATOR || cgs.be.markedTeam[clientNum])
+		if (isSpec && (cg_teamIndicator.integer & PI_SPECTATOR) || cgs.be.markedTeam[clientNum])
 			CG_FillRect(rectX, rectY, rectW, rectH, teamColor);
 	}
 
@@ -2802,7 +2802,7 @@ void CG_DrawPlayerIndicator(int clientNum)
 			    NULL,
 			    w2, h2,
 			    SCREEN_WIDTH,
-			    DS_SHADOW | DS_PROPORTIONAL | DS_HCENTER,
+			    DS_PROPORTIONAL | DS_HCENTER,
 			    bgColor,
 			    NULL,
 			    NULL

--- a/code/cgame/cg_drawtools.c
+++ b/code/cgame/cg_drawtools.c
@@ -3187,7 +3187,7 @@ void CG_OSPDrawStringNew(float x, float y, const char* string, const vec4_t setC
 		CG_OSPDrawFrame(ax, ay, expectedLenght, ah, border, borderColor, 0);
 	}
 
-	shadowEnabled = (flags & DS_SHADOW) && (shadowColor[3] != 0.0f);
+	shadowEnabled = (flags & DS_SHADOW) && (shadowColor && shadowColor[3] != 0.0f);
 	if (shadowEnabled)
 	{
 		xx_add = charWidth / 10.0f;

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -806,10 +806,10 @@ typedef struct
 	qhandle_t   viewBloodShader;
 	qhandle_t   damageIndicatorCenter;
 	qhandle_t   tracerShader;
-	qhandle_t   crosshairShader[NUM_CROSSHAIRS + 1];
-	qhandle_t   crosshairShader45[NUM_CROSSHAIRS + 1];
-	qhandle_t   crosshairDecorShader[NUM_CROSSHAIRS + 1];
-	qhandle_t   crosshairDecorShader45[NUM_CROSSHAIRS + 1];
+	qhandle_t   crosshairShader[NUM_CROSSHAIRS];
+	qhandle_t   crosshairShader45[NUM_CROSSHAIRS];
+	qhandle_t   crosshairDecorShader[NUM_CROSSHAIRS];
+	qhandle_t   crosshairDecorShader45[NUM_CROSSHAIRS];
 	int         numberOfCrosshairs;
 	int         numberOfCrosshairDecors;
 	qhandle_t   lagometerShader;

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -2361,6 +2361,11 @@ void CG_BEStatsResetInit(void);
 //cg_cvardescriptions.c
 //
 void CG_RegisterCvarDescriptions(void);
+
+//
+//cg_bescoreboard.c
+//
+int CG_DrawSpectatorList(int yStart, float baseX, short isDouble);
 //===============================================
 
 //
@@ -2619,6 +2624,7 @@ extern int statsInfo[24];
 #define OSP_STATS_WEAPON_MASK       21
 #define OSP_STATS_UNKNOWN1          22
 #define OSP_STATS_UNKNOWN2          23
+#define OSP_STATS_NUM               24
 
 
 // OSP Custom client

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -806,10 +806,10 @@ typedef struct
 	qhandle_t   viewBloodShader;
 	qhandle_t   damageIndicatorCenter;
 	qhandle_t   tracerShader;
-	qhandle_t   crosshairShader[NUM_CROSSHAIRS];
-	qhandle_t   crosshairShader45[NUM_CROSSHAIRS];
-	qhandle_t   crosshairDecorShader[NUM_CROSSHAIRS];
-	qhandle_t   crosshairDecorShader45[NUM_CROSSHAIRS];
+	qhandle_t   crosshairShader[NUM_CROSSHAIRS + 1];
+	qhandle_t   crosshairShader45[NUM_CROSSHAIRS + 1];
+	qhandle_t   crosshairDecorShader[NUM_CROSSHAIRS + 1];
+	qhandle_t   crosshairDecorShader45[NUM_CROSSHAIRS + 1];
 	int         numberOfCrosshairs;
 	int         numberOfCrosshairDecors;
 	qhandle_t   lagometerShader;

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -1101,7 +1101,7 @@ static void CG_InjectCustomLoc(char* str, int size)
 
 void CG_BEParseStatsInfo(void)
 {
-	static int lastStatsInfo[MAX_QPATH] = { 0 };
+	static int lastStatsInfo[OSP_STATS_NUM] = { 0 };
 	char args[1024];
 	int i, weaponIndex, arg_cnt;
 	int hits, shots, kills, deaths;
@@ -1119,7 +1119,10 @@ void CG_BEParseStatsInfo(void)
 
 	int totalArgs = trap_Argc();
 
-	for (i = 0; i < totalArgs - 1 && i < MAX_QPATH; i++)
+	// Don't leave garbage; useful when totalArgs < OSP_STATS_NUM
+	memset(statsInfo, 0, sizeof(statsInfo));
+
+	for (i = 0; i < totalArgs - 1 && i < OSP_STATS_NUM; i++)
 	{
 		trap_Argv(i + 1, args, sizeof(args));
 		statsInfo[i] = atoi(args);
@@ -1131,7 +1134,7 @@ void CG_BEParseStatsInfo(void)
 	if (!changed)
 		return;
 
-	memcpy(lastStatsInfo, statsInfo, sizeof(int) * MAX_QPATH);
+	memcpy(lastStatsInfo, statsInfo, sizeof(statsInfo));
 
 	if (cgs.osp.gameTypeFreeze)
 	{
@@ -1145,7 +1148,8 @@ void CG_BEParseStatsInfo(void)
 
 	arg_cnt = 23;
 
-	for (weaponIndex = 0; weaponIndex < WP_NUM_WEAPONS; weaponIndex++)
+	// weaponIndex = 1: WP_NONE should always be ignored even if weapon mask has it flagged
+	for (weaponIndex = 1; weaponIndex < WP_NUM_WEAPONS; weaponIndex++)
 	{
 		if (statsInfo[OSP_STATS_WEAPON_MASK] & (1 << weaponIndex))
 		{

--- a/code/cgame/cg_superhud_element_ng.c
+++ b/code/cgame/cg_superhud_element_ng.c
@@ -23,7 +23,7 @@ void* CG_SHUDElementNGCreate(const superhudConfig_t* config)
 	}
 
 	CG_SHUDTextMakeContext(&element->config, &element->tctx);
-	CG_SHUDFillAndFrameForText(&element->config, &element->ctx);
+	CG_SHUDFillAndFrameForText(&element->config, &element->tctx);
 
 	element->tctx.coord.named.x = 320;
 	element->tctx.coord.named.y = 232;

--- a/code/cgame/cg_superhud_private.h
+++ b/code/cgame/cg_superhud_private.h
@@ -861,6 +861,10 @@ const superHUDConfigElement_t* CG_SHUDAvailableElementsGet(void);
 
 int CG_SHUDGetAmmo(int wpi);
 
+void CG_SHUDFillAndFrameForText(superhudConfig_t* cfg, superhudTextContext_t* ctx);
+qboolean CG_SHUDDrawBorder(const superhudConfig_t* cfg);
+void CG_SHUDConfigPickBorderColor(const superhudConfig_t* config, float* color, qboolean alphaOverride);
+void CG_SHUDDrawBorderDirect(const superhudCoord_t* coord, const vec4_t border, const vec4_t borderColor);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Fixed `statsinfo` erroneously not ignoring `WP_NONE` in weapon mask.
- Linux native now builds.
- Patched segfaults in `statsinfo` and `teamIndicator` with `PI_FROZEN` flagged.
- Undefined behaviour fixes

> [!WARNING]
> Linux qvm seems not to be broken, as well as *.so does no more segfaults. The mod stuff works fine, but I haven't stress-tested it yet. During segfault fixes I was trying to preserve behaviour as it was in qvm, but beware of possible bugs **not** caused by theese fixes.

I also ran the code through sanitizer with `-fsanitize=undefined` and `-fsanitize=address` separately and they showed no runtime errors in your code. There are RE on some parts from OSP2, but I'll open a new pull request to snems's repo, though they do not cause crashes.

**Waiting for your review. Feel free to left some change requirements or codestyle flaws.**

> [!NOTE]
> For some reason, having vanilla OSP2 forked makes github forbidding to fork OSP2-BE into personal account. So I had to fork it into my own organization.